### PR TITLE
Add primordial stones

### DIFF
--- a/items/other.toml
+++ b/items/other.toml
@@ -368,7 +368,7 @@ items = [
     199170,
 ]
 
-[primordialstones]
+[primordial_stones]
 name = "Primordial Stones"
 description = { _ = "Primordial Stones for the Onyx Annulet" }
 color = 0x48AA00

--- a/items/other.toml
+++ b/items/other.toml
@@ -368,6 +368,48 @@ items = [
     199170,
 ]
 
+[primordialstones]
+name = "Primordial Stones"
+description = { _ = "Primordial Stones for the Onyx Annulet" }
+color = 0x48AA00
+
+items = [
+    # Gems
+    204000,
+    204001,
+    204002,
+    204003,
+    204004,
+    204005,
+    204006,
+    204007,
+    204009,
+    204010,
+    204011,
+    204012,
+    204013,
+    204014,
+    204015,
+    204018,
+    204019,
+    204020,
+    204021,
+    204022,
+    204025,
+    204027,
+    204029,
+    204030,
+    # Components
+    204215,
+    204573,
+    204574,
+    204575,
+    204576,
+    204577,
+    204578,
+    204579,
+]
+
 [reputation_items]
 name = "Reputation Items"
 description = { _ = "Contains Items which can be directly traded in for reputation/renown, as well as items needed for Wrathion & Sabellian" }


### PR DESCRIPTION
Adding a group for the 10.0.7 Primordial Stones. I pulled the item IDs from https://www.wowhead.com/guide/forbidden-reach/primordial-stones. Wasn't sure if you'd want a separate group for the Condensed Magic items vs the actual gems, so I placed a comment separating them out for now.

Also, I'm not sure how you choose colors, so this currently uses the same color as the Darkmoon Cards.