### PR TITLE
add Echoing Storm Flightstone in Cavern Currencies

### DIFF
--- a/items/embers_of_neltharion.toml
+++ b/items/embers_of_neltharion.toml
@@ -20,6 +20,7 @@ items = [
     205188,
     205247,
     205248,
+    205962,
     205982,
     205984,
     205686, # Clacking Claw - not really a currency, but a singular item belonging into the cave


### PR DESCRIPTION
Not a currency but the bag contains 10xFlightstone