### PR TITLE
Include Large Shadowflame Residue Sack

### DIFF
--- a/items/embers_of_neltharion.toml
+++ b/items/embers_of_neltharion.toml
@@ -8,7 +8,7 @@ merged_by_default = false
 name = "Shadowflame Crests"
 description = { _ = "This category contains Shadowflame Crests, which can be used to upgrade gear." }
 color = 0xFF2400
-items = [204075, 204076, 204077, 204078, 204193, 204194, 204195, 204196, 205423]
+items = [204075, 204076, 204077, 204078, 204193, 204194, 204195, 204196, 205423, 205682]
 
 [cavern_currencies]
 name = "Cavern Currencies"


### PR DESCRIPTION
Includes the large version of Shadowflame Residue Sack.
https://www.wowhead.com/item=205682/large-shadowflame-residue-sack